### PR TITLE
refactor: Remove flag values from global state

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -1,12 +1,6 @@
 package cmd
 
-import (
-	"github.com/spf13/cobra"
-)
-
-var (
-	cost    bool
-)
+import "github.com/spf13/cobra"
 
 var awsCmd = &cobra.Command{
 	Use:   "aws",
@@ -25,7 +19,7 @@ func init() {
 
 	awsCmd.PersistentFlags().StringP("account", "a", "", "AWS account ID")
 	awsCmd.PersistentFlags().StringP("region", "r", "", "AWS region ID")
-	awsCmd.PersistentFlags().BoolVarP(&cost, "cost", "c", false, "AWS ami estimated cost")
+	awsCmd.PersistentFlags().BoolP("cost", "c", false, "AWS ami estimated cost")
 
 	_ = awsCmd.MarkPersistentFlagRequired("account")
 	_ = awsCmd.MarkPersistentFlagRequired("region")

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -5,7 +5,6 @@ import (
 )
 
 var (
-	region  string
 	cost    bool
 )
 
@@ -25,7 +24,7 @@ func init() {
 	rootCmd.AddCommand(awsCmd)
 
 	awsCmd.PersistentFlags().StringP("account", "a", "", "AWS account ID")
-	awsCmd.PersistentFlags().StringVarP(&region, "region", "r", "", "AWS region ID")
+	awsCmd.PersistentFlags().StringP("region", "r", "", "AWS region ID")
 	awsCmd.PersistentFlags().BoolVarP(&cost, "cost", "c", false, "AWS ami estimated cost")
 
 	_ = awsCmd.MarkPersistentFlagRequired("account")

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -5,7 +5,6 @@ import (
 )
 
 var (
-	account string
 	region  string
 	cost    bool
 )
@@ -16,18 +15,18 @@ var awsCmd = &cobra.Command{
 	Long:  `Manages AWS AMIs by account and region`,
 	Example: `  amictl aws list-all --account 123456789012 --region us-east-1
   amictl aws list-unused --account 123456789012 --region us-east-1`,
+	TraverseChildren: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Println(cmd.Long)
 	},
-	TraverseChildren: true,
 }
 
 func init() {
 	rootCmd.AddCommand(awsCmd)
 
-	awsCmd.PersistentFlags().StringVarP(&account, "account", "a", "", "AWS account ID")
+	awsCmd.PersistentFlags().StringP("account", "a", "", "AWS account ID")
 	awsCmd.PersistentFlags().StringVarP(&region, "region", "r", "", "AWS region ID")
-	awsCmd.PersistentFlags().BoolVarP(&cost, "cost", "c", false, "Estimated Cost")
+	awsCmd.PersistentFlags().BoolVarP(&cost, "cost", "c", false, "AWS ami estimated cost")
 
 	_ = awsCmd.MarkPersistentFlagRequired("account")
 	_ = awsCmd.MarkPersistentFlagRequired("region")

--- a/cmd/aws_list_all.go
+++ b/cmd/aws_list_all.go
@@ -56,6 +56,11 @@ func runAll(cmd *cobra.Command, args []string) error {
 	l := aws2.ListAll(a)
 	r := strings.Join(l, "\n")
 
+	cost, err := cmd.Flags().GetBool("cost")
+	if err != nil {
+		return err
+	}
+
 	if cost == true {
 		var total float64
 		for _, ami := range a.Images {

--- a/cmd/aws_list_all.go
+++ b/cmd/aws_list_all.go
@@ -36,6 +36,11 @@ func runAll(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	region, err := cmd.Flags().GetString("region")
+	if err != nil {
+		return err
+	}
+
 	// Establishes new authenticated session to AWS
 	sess, err := aws2.NewSession(region)
 	if err != nil {

--- a/cmd/aws_list_all.go
+++ b/cmd/aws_list_all.go
@@ -24,6 +24,10 @@ var listAll = &cobra.Command{
 }
 
 func runAll(cmd *cobra.Command, args []string) error {
+	account, err := cmd.Flags().GetString("account")
+	if err != nil {
+		return err
+	}
 
 	// Creates a input filter to get AMIs
 	f := &ec2.DescribeImagesInput{

--- a/cmd/aws_list_unused.go
+++ b/cmd/aws_list_unused.go
@@ -62,6 +62,11 @@ func runUnused(cmd *cobra.Command, args []string) error {
 	n := commons.Compare(l, u)
 	r := strings.Join(n, "\n")
 
+	cost, err := cmd.Flags().GetBool("cost")
+	if err != nil {
+		return err
+	}
+
 	if cost == true {
 		var total float64
 		for _, i := range n {

--- a/cmd/aws_list_unused.go
+++ b/cmd/aws_list_unused.go
@@ -36,6 +36,11 @@ func runUnused(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	region, err := cmd.Flags().GetString("region")
+	if err != nil {
+		return err
+	}
+
 	// Establishes new authenticated session to AWS
 	sess, err := aws2.NewSession(region)
 	if err != nil {

--- a/cmd/aws_list_unused.go
+++ b/cmd/aws_list_unused.go
@@ -24,10 +24,15 @@ var listUnused = &cobra.Command{
 }
 
 func runUnused(cmd *cobra.Command, args []string) error {
+	account, err := cmd.Flags().GetString("account")
+	if err != nil {
+		return err
+	}
+
 	// Creates a input filter to get AMIs
 	f := &ec2.DescribeImagesInput{
 		Owners: []*string{
-			aws.String(account),
+			&account,
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 var rootCmd = &cobra.Command{
 	Use:   "amictl",
 	Short: "amictl is a CLI to control your AMIs and Images.",


### PR DESCRIPTION
The objective of this PR is remove flag variables from global state of cli. This keep process safe to any side affect that possible change this global values.