### PR TITLE
feat: stylize outputs mesages for unused AMIs

### DIFF
--- a/cmd/awsListUnused.go
+++ b/cmd/awsListUnused.go
@@ -104,13 +104,13 @@ func runUnused(cmd *cobra.Command, _ []string) error {
 
 	err = pterm.DefaultTable.WithHasHeader().WithData(d).Render()
 
-	if (l > 20) && (l < 50) {
+	if (l <= 20){
+		pterm.Println(pterm.Green(fmt.Sprintf("%d AMIs are not being utilized.", l)))
+	} else if (l > 20) && (l < 50) {
 		pterm.Println(pterm.Yellow(fmt.Sprintf("%d AMIs are not being utilized.", l)))
 	} else if ( l >= 50) { 
 		pterm.Println(pterm.Red(fmt.Sprintf("%d AMIs are not being utilized.", l)))
-	} else if (l <= 20){
-		pterm.Println(pterm.Green(fmt.Sprintf("%d AMIs are not being utilized.", l)))
 	}
-
+		
 	return nil
 }


### PR DESCRIPTION
This feature customizes output messages to unused AMIs:

* Less than or equal to 20 = Green
* Greater than 20 and less than 50 = Yellow
* Greater than or equal to 50 = red  

Issue : #28 